### PR TITLE
Remove Fuzzy Matching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add python3-dev && \
     apk add --no-cache postgresql-libs && \
     apk add --no-cache --virtual .build-deps gcc musl-dev postgresql-dev && \
     pip3 install -r requirements.txt
-ENV WEB_CONCURRENCY=3
+ENV WEB_CONCURRENCY=4
 RUN adduser -D myuser
 USER myuser
 CMD gunicorn --bind 0.0.0.0:$PORT "app.web:app"

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apk add python3-dev && \
     apk add --no-cache postgresql-libs && \
     apk add --no-cache --virtual .build-deps gcc musl-dev postgresql-dev && \
     pip3 install -r requirements.txt
+ENV WEB_CONCURRENCY=3
 RUN adduser -D myuser
 USER myuser
 CMD gunicorn --bind 0.0.0.0:$PORT "app.web:app"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
             - POSTGRES_PASSWORD=postgres
             - PORT=8000
             - PYTHONPATH='/usr/src/app'
+            - WEB_CONCURRENCY=3
         volumes:
             - ./src:/usr/src/
         working_dir: /usr/src/
@@ -30,4 +31,4 @@ services:
             - "8000:8000"
         tty: true
         stdin_open: true
-        command: /usr/local/bin/gunicorn --reload "app.web:app" -b 0.0.0.0:8000 
+        command: /usr/local/bin/gunicorn --reload "app.web:app" -b 0.0.0.0:8000  

--- a/pg/db_init/init_db.sh
+++ b/pg/db_init/init_db.sh
@@ -16,6 +16,8 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-E
         longitude    real,
         accuracy     smallint
     );
+    CREATE INDEX city_state_code on geo (UPPER(city || state_code));
+    CREATE INDEX city_state on geo (UPPER(city || state));
     COPY geo FROM '/app/data/US.txt' WITH (FORMAT CSV, DELIMITER E'\t', FORCE_NULL(accuracy));
 EOSQL
 ogr2ogr -f "PostgreSQL" PG:"dbname=postgres  user=postgres" "data/indigenousTerritories.json"

--- a/src/app/db.py
+++ b/src/app/db.py
@@ -32,8 +32,6 @@ class GeoData():
             SELECT city, state, state_code, latitude, longitude from geo
             WHERE UPPER(concat(city, state)) = %(s)s
             OR UPPER(concat(city, state_code)) = %(s)s
-            OR metaphone(concat(city, state), 10) = metaphone(%(s)s, 10)
-            OR metaphone(concat(city, state_code), 10) = metaphone(%(s)s, 10)
             LIMIT 1
             '''
         with self.connection.cursor(cursor_factory=DictCursor) as cur:

--- a/src/app/db.py
+++ b/src/app/db.py
@@ -11,14 +11,13 @@ class GeoData():
         self.connection = None
 
     def connect(self):
-        if True:
-            try:
-                self.connection = psycopg2.connect(self.db_url)
-            except psycopg2.DatabaseError as e:
-                logger.error(e)
-                raise e
-            finally:
-                logger.info('Connected to database')
+        try:
+            self.connection = psycopg2.connect(self.db_url)
+        except psycopg2.DatabaseError as e:
+            logger.error(e)
+            raise e
+        finally:
+            logger.info('Connected to database')
 
     def query_location(self, location):
         '''

--- a/src/app/db.py
+++ b/src/app/db.py
@@ -11,7 +11,7 @@ class GeoData():
         self.connection = None
 
     def connect(self):
-        if self.connection is None:
+        if True:
             try:
                 self.connection = psycopg2.connect(self.db_url)
             except psycopg2.DatabaseError as e:
@@ -28,17 +28,17 @@ class GeoData():
             return self.query_zip(location)
 
         smushed_name = re.sub(r'\W+', '', location).upper()
+
         query = '''
             SELECT city, state, state_code, latitude, longitude from geo
-            WHERE metaphone(concat(city, state), 10) = metaphone(%s, 10)
-            OR metaphone(concat(city, state_code), 10) = metaphone(%s, 10)
-            OR levenshtein(UPPER(CONCAT(city, state)), %s) < 2
-            OR levenshtein(UPPER(CONCAT(city, state_code)), %s) < 2
-            ORDER by levenshtein(UPPER(CONCAT(city, state_code)), %s)
+            WHERE UPPER(concat(city, state)) = %(s)s
+            OR UPPER(concat(city, state_code)) = %(s)s
+            OR metaphone(concat(city, state), 10) = metaphone(%(s)s, 10)
+            OR metaphone(concat(city, state_code), 10) = metaphone(%(s)s, 10)
             LIMIT 1
             '''
         with self.connection.cursor(cursor_factory=DictCursor) as cur:
-            cur.execute(query, (smushed_name, smushed_name, smushed_name, smushed_name, smushed_name))
+            cur.execute(query, {'s': smushed_name})
             return cur.fetchone()
 
     def query_zip(self, zipcode):

--- a/src/app/web.py
+++ b/src/app/web.py
@@ -5,7 +5,8 @@ from .db import GeoData
 
 def make_twilML(req, resp, resource):
     twil_resp = MessagingResponse()
-    resp.body = str(twil_resp.message(resp.body))
+    twil_resp.message(resp.body)
+    resp.body = str(twil_resp)
 
 
 @falcon.after(make_twilML)


### PR DESCRIPTION
This temporarily removes the levenshtein distance calcs in postgres. While this runs well locally, it's a little taxing on the heroku  postgres. It also adds env to set gunicorn concurrency to something other than 1. This PR reflects the code that is actually running on Heroku after yesterday's hotfix.